### PR TITLE
feat: modernize admin layout with glass UI and theme toggle

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,24 +1,58 @@
 "use client";
 import Link from 'next/link';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useI18n } from '@/i18n';
 import LocaleSwitcher from '@/components/ui/LocaleSwitcher';
+import ThemeToggle from '@/components/ui/ThemeToggle';
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const { t } = useI18n();
+  const [collapsed, setCollapsed] = useState(false);
   return (
-    <div className="min-h-screen grid grid-cols-[200px_1fr]">
-      <aside className="bg-slate-100 p-4 space-y-4 flex flex-col">
-        <h2 className="font-bold">BakeCake</h2>
-        <nav className="flex flex-col gap-2">
-          <Link href="/admin/dashboard">{t('Navigation.dashboard')}</Link>
-          <Link href="/admin/catalog/categories">{t('Navigation.categories')}</Link>
-          <Link href="/admin/catalog/products">{t('Navigation.products')}</Link>
-          <Link href="/admin/vendors">{t('Navigation.vendors')}</Link>
+    <div className="min-h-screen w-full flex text-slate-900 dark:text-slate-100">
+      <aside
+        className={`bg-white/70 dark:bg-white/5 backdrop-blur-xl border-r border-white/10 transition-all ${collapsed ? 'w-20' : 'w-64'} p-4 flex flex-col`}
+      >
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="self-end mb-4 text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-white"
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          {collapsed ? '›' : '‹'}
+        </button>
+        <h2 className={`font-bold mb-6 ${collapsed ? 'text-center text-sm' : 'text-lg'}`}>{collapsed ? 'BC' : 'BakeCake'}</h2>
+        <nav className="flex flex-col gap-2 flex-1">
+          <Link href="/admin/dashboard" className="hover:text-indigo-500 dark:hover:text-indigo-400">
+            {t('Navigation.dashboard')}
+          </Link>
+          <Link href="/admin/catalog/categories" className="hover:text-indigo-500 dark:hover:text-indigo-400">
+            {t('Navigation.categories')}
+          </Link>
+          <Link href="/admin/catalog/products" className="hover:text-indigo-500 dark:hover:text-indigo-400">
+            {t('Navigation.products')}
+          </Link>
+          <Link href="/admin/vendors" className="hover:text-indigo-500 dark:hover:text-indigo-400">
+            {t('Navigation.vendors')}
+          </Link>
         </nav>
-        <LocaleSwitcher />
       </aside>
-      <main className="p-6">{children}</main>
+      <div className="flex-1 flex flex-col">
+        <header className="flex items-center justify-end gap-4 p-4 bg-white/70 dark:bg-white/5 backdrop-blur-xl border-b border-white/10">
+          <ThemeToggle />
+          <button aria-label="Notifications" className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-white">
+            🔔
+          </button>
+          <LocaleSwitcher />
+          <button aria-label="Profile" className="h-8 w-8 rounded-full bg-indigo-600 text-white">
+            U
+          </button>
+        </header>
+        <main className="p-6 flex-1 overflow-auto">
+          <div className="h-full w-full rounded-xl bg-white/70 dark:bg-white/5 backdrop-blur-xl border border-white/10 p-6">
+            {children}
+          </div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,13 +22,7 @@ export default async function RootLayout({
     <html lang={locale} className="h-full">
       <body className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-950 dark:to-black text-slate-900 dark:text-slate-100 antialiased transition-colors">
         <I18nProvider initialLocale={locale} initialMessages={messages}>
-          {/* Global wrapper */}
-          <div className="flex flex-col min-h-screen">
-            {/* Page content */}
-            <main className="flex-1 flex items-center justify-center">
-              {children}
-            </main>
-          </div>
+          {children}
         </I18nProvider>
       </body>
     </html>

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('theme');
+    if (stored === 'light') {
+      document.documentElement.classList.remove('dark');
+      setIsDark(false);
+    } else {
+      document.documentElement.classList.add('dark');
+      setIsDark(true);
+    }
+  }, []);
+
+  const toggle = () => {
+    const html = document.documentElement;
+    if (isDark) {
+      html.classList.remove('dark');
+      window.localStorage.setItem('theme', 'light');
+      setIsDark(false);
+    } else {
+      html.classList.add('dark');
+      window.localStorage.setItem('theme', 'dark');
+      setIsDark(true);
+    }
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle theme"
+      className="text-slate-400 hover:text-slate-200 dark:text-slate-400 dark:hover:text-white"
+    >
+      {isDark ? '🌙' : '☀️'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- restyle admin layout with collapsible glass sidebar and header controls
- add client-side theme toggle and relocate locale switcher to header
- simplify root layout to allow full-width admin pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to write page endpoint /_error)*

------
https://chatgpt.com/codex/tasks/task_e_68bd255ad1bc832baee0746d0a6d9b26