### PR TITLE
feat: improve admin shell with collapsible sidebar and header

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,24 +1,75 @@
 "use client";
+
 import Link from 'next/link';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useI18n } from '@/i18n';
 import LocaleSwitcher from '@/components/ui/LocaleSwitcher';
+import ThemeToggle from '@/components/ui/ThemeToggle';
+import Notifications from '@/components/ui/Notifications';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconDashboard,
+  IconFolder,
+  IconBox,
+  IconUsers,
+} from '@/components/ui/Icons';
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const { t } = useI18n();
+  const [collapsed, setCollapsed] = useState(false);
+
+  const nav = [
+    { href: '/admin/dashboard', label: t('Navigation.dashboard'), icon: IconDashboard },
+    { href: '/admin/catalog/categories', label: t('Navigation.categories'), icon: IconFolder },
+    { href: '/admin/catalog/products', label: t('Navigation.products'), icon: IconBox },
+    { href: '/admin/vendors', label: t('Navigation.vendors'), icon: IconUsers },
+  ];
+
   return (
-    <div className="min-h-screen grid grid-cols-[200px_1fr]">
-      <aside className="bg-slate-100 p-4 space-y-4 flex flex-col">
-        <h2 className="font-bold">BakeCake</h2>
-        <nav className="flex flex-col gap-2">
-          <Link href="/admin/dashboard">{t('Navigation.dashboard')}</Link>
-          <Link href="/admin/catalog/categories">{t('Navigation.categories')}</Link>
-          <Link href="/admin/catalog/products">{t('Navigation.products')}</Link>
-          <Link href="/admin/vendors">{t('Navigation.vendors')}</Link>
+    <div className="min-h-screen flex bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-950">
+      {/* Sidebar */}
+      <aside
+        className={`transition-all duration-300 flex flex-col border-r border-white/20 bg-white/60 dark:bg-slate-800/60 backdrop-blur-md p-4 ${collapsed ? 'w-16' : 'w-60'}`}
+      >
+        <div className="flex items-center justify-between mb-6">
+          {!collapsed && <h2 className="font-bold">BakeCake</h2>}
+          <button
+            onClick={() => setCollapsed((c) => !c)}
+            className="text-slate-600 dark:text-slate-300"
+            aria-label="Toggle sidebar"
+          >
+            {collapsed ? (
+              <IconChevronRight className="h-5 w-5" />
+            ) : (
+              <IconChevronLeft className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+        <nav className="flex flex-col gap-2 flex-1">
+          {nav.map(({ href, label, icon: Icon }) => (
+            <Link
+              key={href}
+              href={href}
+              className="flex items-center gap-3 px-2 py-1 rounded hover:bg-slate-100/60 dark:hover:bg-slate-700/60"
+            >
+              <Icon className="h-5 w-5" />
+              {!collapsed && <span>{label}</span>}
+            </Link>
+          ))}
         </nav>
-        <LocaleSwitcher />
       </aside>
-      <main className="p-6">{children}</main>
+
+      {/* Content area */}
+      <div className="flex-1 flex flex-col">
+        <header className="h-14 flex items-center justify-end gap-4 px-4 border-b border-white/20 bg-white/60 backdrop-blur-md dark:bg-slate-800/60">
+          <ThemeToggle />
+          <Notifications />
+          <LocaleSwitcher />
+          <div className="w-8 h-8 rounded-full bg-indigo-600 text-white grid place-items-center text-sm">A</div>
+        </header>
+        <main className="flex-1 p-6">{children}</main>
+      </div>
     </div>
   );
 }

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center w-full">
+      {children}
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,12 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} className="h-full">
-      <body className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-950 dark:to-black text-slate-900 dark:text-slate-100 antialiased transition-colors">
+      <body className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 text-slate-900 dark:text-slate-100 antialiased transition-colors">
         <I18nProvider initialLocale={locale} initialMessages={messages}>
           {/* Global wrapper */}
           <div className="flex flex-col min-h-screen">
             {/* Page content */}
-            <main className="flex-1 flex items-center justify-center">
-              {children}
-            </main>
+            <main className="flex-1">{children}</main>
           </div>
         </I18nProvider>
       </body>

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -1,0 +1,90 @@
+import { SVGProps } from 'react';
+
+export function IconSun(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+export function IconMoon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+    </svg>
+  );
+}
+
+export function IconBell(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M12 22a2 2 0 002-2h-4a2 2 0 002 2z" />
+      <path d="M18 16v-5a6 6 0 10-12 0v5l-2 2h16l-2-2z" />
+    </svg>
+  );
+}
+
+export function IconChevronLeft(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M15 19l-7-7 7-7" />
+    </svg>
+  );
+}
+
+export function IconChevronRight(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+export function IconDashboard(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <rect x="3" y="3" width="8" height="8" />
+      <rect x="13" y="3" width="8" height="8" />
+      <rect x="13" y="13" width="8" height="8" />
+      <rect x="3" y="13" width="8" height="8" />
+    </svg>
+  );
+}
+
+export function IconFolder(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V7a2 2 0 00-2-2h-7l-2-2H5a2 2 0 00-2 2z" />
+    </svg>
+  );
+}
+
+export function IconBox(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M12 2l8 4v8l-8 4-8-4V6l8-4z" />
+      <path d="M12 22V12" />
+      <path d="M20 6l-8 4-8-4" />
+    </svg>
+  );
+}
+
+export function IconUsers(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="8" cy="8" r="3" />
+      <circle cx="16" cy="8" r="3" />
+      <path d="M2 20c0-3 4-5 6-5h8c2 0 6 2 6 5" />
+    </svg>
+  );
+}
+

--- a/src/components/ui/Notifications.tsx
+++ b/src/components/ui/Notifications.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from 'react';
+import { IconBell } from '@/components/ui/Icons';
+
+interface Notification {
+  id: number;
+  text: string;
+}
+
+const sample: Notification[] = [
+  { id: 1, text: 'Welcome to BakeCake!' },
+  { id: 2, text: 'Your profile is 80% complete.' },
+];
+
+export default function Notifications() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="relative text-slate-600 dark:text-slate-300"
+        aria-label="Notifications"
+      >
+        <IconBell className="h-5 w-5" />
+        {sample.length > 0 && (
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-[10px] w-4 h-4 grid place-items-center">
+            {sample.length}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-56 rounded-lg border border-white/20 bg-white/90 p-2 text-sm shadow-lg backdrop-blur-md dark:bg-slate-800/90">
+          {sample.map((n) => (
+            <div
+              key={n.id}
+              className="rounded px-2 py-1 hover:bg-slate-100/60 dark:hover:bg-slate-700/60"
+            >
+              {n.text}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { IconMoon, IconSun } from '@/components/ui/Icons';
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      document.documentElement.classList.add('dark');
+      setDark(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (dark) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [dark]);
+
+  return (
+    <button
+      onClick={() => setDark(!dark)}
+      className="text-slate-600 dark:text-slate-300"
+      aria-label="Toggle theme"
+    >
+      {dark ? <IconMoon className="h-5 w-5" /> : <IconSun className="h-5 w-5" />}
+    </button>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- add collapsible glass sidebar and top bar with utilities
- support dark/light themes with toggle and Tailwind class mode
- center auth pages with dedicated layout
- replace emoji placeholders with reusable SVG icons for nav, theme toggle and notifications

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd255ad1bc832baee0746d0a6d9b26