### PR TITLE
feat: add top nav and profile locale dropdown

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,73 +1,26 @@
 "use client";
 
-import Link from 'next/link';
-import { ReactNode, useState } from 'react';
-import { useI18n } from '@/i18n';
-import LocaleSwitcher from '@/components/ui/LocaleSwitcher';
+import { ReactNode } from 'react';
+import Sidebar from '@/components/navigation/Sidebar';
+import TopNav from '@/components/navigation/TopNav';
 import ThemeToggle from '@/components/ui/ThemeToggle';
-
 import Notifications from '@/components/ui/Notifications';
-import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconDashboard,
-  IconFolder,
-  IconBox,
-  IconUsers,
-} from '@/components/ui/Icons';
+import ProfileMenu from '@/components/ui/ProfileMenu';
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
-  const { t } = useI18n();
-  const [collapsed, setCollapsed] = useState(false);
-
-  const nav = [
-    { href: '/admin/dashboard', label: t('Navigation.dashboard'), icon: IconDashboard },
-    { href: '/admin/catalog/categories', label: t('Navigation.categories'), icon: IconFolder },
-    { href: '/admin/catalog/products', label: t('Navigation.products'), icon: IconBox },
-    { href: '/admin/vendors', label: t('Navigation.vendors'), icon: IconUsers },
-  ];
-
   return (
     <div className="min-h-screen flex bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-950">
-      {/* Sidebar */}
-      <aside
-        className={`transition-all duration-300 flex flex-col border-r border-white/20 bg-white/60 dark:bg-slate-800/60 backdrop-blur-md p-4 ${collapsed ? 'w-16' : 'w-60'}`}
-      >
-        <div className="flex items-center justify-between mb-6">
-          {!collapsed && <h2 className="font-bold">BakeCake</h2>}
-          <button
-            onClick={() => setCollapsed((c) => !c)}
-            className="text-slate-600 dark:text-slate-300"
-            aria-label="Toggle sidebar"
-          >
-            {collapsed ? (
-              <IconChevronRight className="h-5 w-5" />
-            ) : (
-              <IconChevronLeft className="h-5 w-5" />
-            )}
-          </button>
-        </div>
-        <nav className="flex flex-col gap-2 flex-1">
-          {nav.map(({ href, label, icon: Icon }) => (
-            <Link
-              key={href}
-              href={href}
-              className="flex items-center gap-3 px-2 py-1 rounded hover:bg-slate-100/60 dark:hover:bg-slate-700/60"
-            >
-              <Icon className="h-5 w-5" />
-              {!collapsed && <span>{label}</span>}
-            </Link>
-          ))}
-        </nav>
+      <aside className="border-r border-white/20 bg-white/60 p-4 backdrop-blur-md dark:bg-slate-800/60">
+        <Sidebar />
       </aside>
-
-      {/* Content area */}
       <div className="flex-1 flex flex-col">
-        <header className="h-14 flex items-center justify-end gap-4 px-4 border-b border-white/20 bg-white/60 backdrop-blur-md dark:bg-slate-800/60">
-          <ThemeToggle />
-          <Notifications />
-          <LocaleSwitcher />
-          <div className="w-8 h-8 rounded-full bg-indigo-600 text-white grid place-items-center text-sm">A</div>
+        <header className="h-14 flex items-center justify-between gap-4 px-4 border-b border-white/20 bg-white/60 backdrop-blur-md dark:bg-slate-800/60">
+          <TopNav />
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Notifications />
+            <ProfileMenu />
+          </div>
         </header>
         <main className="flex-1 p-6">{children}</main>
       </div>

--- a/src/components/navigation/TopNav.tsx
+++ b/src/components/navigation/TopNav.tsx
@@ -1,0 +1,65 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useMemo } from 'react';
+import { navConfig, NavItem, Role } from '@/navigation/navConfig';
+import { useRole } from '@/contexts/role';
+
+function TopNavItem({ item, role, pathname }: { item: NavItem; role: Role; pathname: string }) {
+  if (item.section) return null;
+  const hasChildren = item.children && item.children.length > 0;
+  const allowedChildren = item.children?.filter(child => !child.roles || child.roles.includes(role));
+
+  if (hasChildren && allowedChildren && allowedChildren.length > 0) {
+    return (
+      <div key={item.key} className="relative group">
+        <button className="px-2 py-1 text-sm font-medium">
+          {item.label}
+        </button>
+        <div className="absolute left-0 mt-1 hidden w-40 flex-col rounded border border-slate-200 bg-white shadow-md group-hover:flex dark:border-slate-700 dark:bg-slate-800">
+          {allowedChildren.map(child =>
+            child.href ? (
+              <Link
+                key={child.key}
+                href={child.href}
+                className="px-4 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-700"
+              >
+                {child.label}
+              </Link>
+            ) : null,
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (item.href) {
+    const active = pathname.startsWith(item.href);
+    return (
+      <Link
+        key={item.key}
+        href={item.href}
+        className={`px-2 py-1 text-sm ${active ? 'font-semibold' : ''}`}
+      >
+        {item.label}
+      </Link>
+    );
+  }
+
+  return null;
+}
+
+export default function TopNav() {
+  const role = useRole();
+  const pathname = usePathname();
+  const items = useMemo(() => navConfig.filter(item => !item.roles || item.roles.includes(role)), [role]);
+
+  return (
+    <nav className="flex gap-4">
+      {items.map(item => (
+        <TopNavItem key={item.key} item={item} role={role} pathname={pathname} />
+      ))}
+    </nav>
+  );
+}
+

--- a/src/components/ui/LocaleSwitcher.tsx
+++ b/src/components/ui/LocaleSwitcher.tsx
@@ -3,17 +3,18 @@ import { useI18n, locales } from '@/i18n';
 
 export default function LocaleSwitcher() {
   const { locale, setLocale } = useI18n();
+
   return (
-    <div className="flex gap-2 text-sm">
-      {locales.map((l) => (
-        <button
-          key={l}
-          onClick={() => setLocale(l)}
-          className={l === locale ? 'font-bold underline' : 'hover:underline'}
-        >
+    <select
+      value={locale}
+      onChange={e => setLocale(e.target.value as (typeof locales)[number])}
+      className="w-full bg-transparent text-sm"
+    >
+      {locales.map(l => (
+        <option key={l} value={l}>
           {l.toUpperCase()}
-        </button>
+        </option>
       ))}
-    </div>
+    </select>
   );
 }

--- a/src/components/ui/ProfileMenu.tsx
+++ b/src/components/ui/ProfileMenu.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useState } from 'react';
+import LocaleSwitcher from '@/components/ui/LocaleSwitcher';
+
+export default function ProfileMenu() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="w-8 h-8 rounded-full bg-indigo-600 text-white grid place-items-center text-sm"
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        A
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 rounded border border-slate-200 bg-white p-2 shadow-md dark:border-slate-700 dark:bg-slate-800">
+          <LocaleSwitcher />
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add horizontal navigation using shared navConfig
- use shared navConfig-based sidebar in admin layout
- add profile menu with locale dropdown

## Testing
- `npm run lint` *(fails: npm command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be2f02c880832b92a4357ab3a6809e